### PR TITLE
Fixed columns in attachments query

### DIFF
--- a/query_attachments.sql
+++ b/query_attachments.sql
@@ -3,7 +3,6 @@ SELECT
   id, 
   filename, 
   time / 1000000 as PosixTime,
-  time, 
   author 
 from attachment
 order by id asc


### PR DESCRIPTION
The expected columns do not include the `time` column. 

Code where columns are used: https://github.com/roskakori/tratihubis/blob/master/tratihubis.py#L477
