### PR TITLE
Error when running without markup conversion

### DIFF
--- a/translator.py
+++ b/translator.py
@@ -66,5 +66,5 @@ class Translator(object):
         return text
 
 class NullTranslator(Translator):
-    def translate(self, text):
+    def translate(self, text, ticketId=''):
         return text


### PR DESCRIPTION
When running tratihubis without `convert_text = true`, the following error occurs:

```
ERROR:tratihubis:translate() got an unexpected keyword argument 'ticketId'
Traceback (most recent call last):
  File "tratihubis/tratihubis.py", line 886, in main
    trac_url=trac_url, convert_text=convert_text, ticketsToRender=ticketsToRender, addComponentLabels=addComponentLabels)
  File "tratihubis/tratihubis.py", line 658, in migrateTickets
    body = translator.translate(body, ticketId=ticketId)
TypeError: translate() got an unexpected keyword argument 'ticketId'
```

This pull request solves the issue by adding an appropriate named argument with a default value to NullTranslator.
